### PR TITLE
ColorAxis Error Fixed [Update highcharts.py] , Heatmap Hover Color Error Fixed [Update common.py]

### DIFF
--- a/highcharts/highcharts/common.py
+++ b/highcharts/highcharts/common.py
@@ -568,6 +568,7 @@ class Hover(CommonObject):
     "marker": (Marker, dict),
     "radius": int,
     "radiusPlus": int,
+    "color": (ColorObject, basestring, dict),
     }
 
 class States(CommonObject):

--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -110,7 +110,7 @@ class Highchart(object):
         # Bind Base Classes to self
         self.options = {
             "chart": ChartOptions(),
-            "colorAxis" : ColorAxisOptions(),
+            #"colorAxis" : ColorAxisOptions(),
             "colors": ColorsOptions(),
             "credits": CreditsOptions(),
             #"data": #NotImplemented
@@ -270,6 +270,9 @@ class Highchart(object):
             self.options[option_type].update_dict(**option_dict)
         elif option_type in ["global" , "lang"]: #Highcharts.setOptions: 
             self.setOptions[option_type].update_dict(**option_dict)
+        elif option_type == 'colorAxis':
+            self.options.update({'colorAxis': ColorAxisOptions()})
+            self.options[option_type].update_dict(**option_dict)
         else:
             self.options[option_type].update_dict(**option_dict)
 


### PR DESCRIPTION
1. The color axis always appears, even if it's not set in some charts like; line charts, spline charts, column charts, etc.
   I've fixed this error by updating highcharts.py .
   ![capture](https://cloud.githubusercontent.com/assets/11185678/16701617/21f50b86-4561-11e6-9526-bfb0fef23c44.PNG)
2. The heatmap can't be updated to change the hover color like this url: http://jsfiddle.net/sgurhhm0/1/
   I always get an error when I try the following:
   self.H.add_data_set(yData,'heatmap',Data_Name,states={'hover': {'color': 'red'}})
   I've fixed this error by updating the Hover class in common.py
