### PR TITLE
Point event fix

### DIFF
--- a/highcharts/highcharts/common.py
+++ b/highcharts/highcharts/common.py
@@ -371,7 +371,7 @@ class Events(CommonObject):
 
 class Point(CommonObject):
     ALLOWED_OPTIONS = {
-    "events": Events
+    "events": (Events, dict)
     }
 
 class Position(CommonObject):


### PR DESCRIPTION
Hi,

I'm in the process of implementing click events on points in a scatter graph, however I'm getting this error:

`Option Type Mismatch: Expected: <class 'highcharts.highcharts.common.Events'>`

Looking through the source code this seems like it may be an easy fix, as the way I'm formatting the options is like so:

```
'point': {
                            'events': {
                                'click': 'function(e) {console.log("Hello!" + e)}'
                            },
                        }
```
Let me know if this isn't the case, it would be great to get this fixed ASAP :)