### PR TITLE
Correct dashStyle option type

### DIFF
--- a/highcharts/highcharts/common.py
+++ b/highcharts/highcharts/common.py
@@ -662,7 +662,7 @@ class PlotBands(ArrayObject):
 class PlotLines(ArrayObject):
     ALLOWED_OPTIONS = {
     "color": (ColorObject, basestring, dict),
-    "dashStyle": int,
+    "dashStyle": basestring,
     "events": (Events, dict),
     "id": basestring,
     "label": (Labels, dict),


### PR DESCRIPTION
The dashStyle param to plotLines takes a string (see http://api.highcharts.com/highcharts/yAxis.plotLines.dashStyle).