### PR TITLE
Stock logarithmic

### DIFF
--- a/highcharts/highstock/options.py
+++ b/highcharts/highstock/options.py
@@ -542,6 +542,10 @@ class yAxisOptions(BaseOptions):
         "tickmarkPlacement": basestring,
         "title": (Title, dict),
         "top": [int, float, basestring],
+        # DEM 2017/11/16: Note that the 'type' keyword for highstock is
+        # undocumented yet appears to be supported, likely because of underlying
+        # shared code.  This permits logarithmic Y-Axis scale which is
+        # frequently useful in stock charts.
         "type": bastestring,
         "units": list    
     }

--- a/highcharts/highstock/options.py
+++ b/highcharts/highstock/options.py
@@ -542,6 +542,7 @@ class yAxisOptions(BaseOptions):
         "tickmarkPlacement": basestring,
         "title": (Title, dict),
         "top": [int, float, basestring],
+        "type": bastestring,
         "units": list    
     }
 

--- a/highcharts/highstock/options.py
+++ b/highcharts/highstock/options.py
@@ -546,7 +546,7 @@ class yAxisOptions(BaseOptions):
         # undocumented yet appears to be supported, likely because of underlying
         # shared code.  This permits logarithmic Y-Axis scale which is
         # frequently useful in stock charts.
-        "type": bastestring,
+        "type": basestring,
         "units": list    
     }
 


### PR DESCRIPTION
Add the keyword for setting highstock Y-Axis to logarithmic scale.  This is supported in the same way as for highchart.

Note that this is an undocumented yet fully supported feature for a long time in highcharts code. 