### PR TITLE
JSONP multisource support

### DIFF
--- a/highcharts/highcharts/highchart_types.py
+++ b/highcharts/highcharts/highchart_types.py
@@ -623,22 +623,23 @@ class Series(object):
 
         # List of dictionaries. Each dict contains data and properties, 
         # which need to handle before construct the object for series 
-        for item in data:
-            if isinstance(item, dict):
-                for k, v in item.items():
-                    if k in DATA_SERIES_ALLOWED_OPTIONS:
-                        if SeriesOptions.__validate_options__(k,v,DATA_SERIES_ALLOWED_OPTIONS[k]):
-                            if isinstance(DATA_SERIES_ALLOWED_OPTIONS[k], tuple):
-                                if isinstance(v, dict):
-                                    item.update({k:DATA_SERIES_ALLOWED_OPTIONS[k][0](**v)})
-                                elif isinstance(v, CommonObject) or isinstance(v, ArrayObject) or \
-                                    isinstance(v, CSSObject) or isinstance(v, SVGObject) or isinstance(v, ColorObject) or \
-                                    isinstance(v, JSfunction) or isinstance(v, Formatter) or isinstance(v, datetime.datetime):
-                                    item.update({k:v})                           
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    for k, v in item.items():
+                        if k in DATA_SERIES_ALLOWED_OPTIONS:
+                            if SeriesOptions.__validate_options__(k,v,DATA_SERIES_ALLOWED_OPTIONS[k]):
+                                if isinstance(DATA_SERIES_ALLOWED_OPTIONS[k], tuple):
+                                    if isinstance(v, dict):
+                                        item.update({k:DATA_SERIES_ALLOWED_OPTIONS[k][0](**v)})
+                                    elif isinstance(v, CommonObject) or isinstance(v, ArrayObject) or \
+                                        isinstance(v, CSSObject) or isinstance(v, SVGObject) or isinstance(v, ColorObject) or \
+                                        isinstance(v, JSfunction) or isinstance(v, Formatter) or isinstance(v, datetime.datetime):
+                                        item.update({k:v})                           
+                                    else:
+                                        item.update({k:DATA_SERIES_ALLOWED_OPTIONS[k][0](v)})
                                 else:
-                                    item.update({k:DATA_SERIES_ALLOWED_OPTIONS[k][0](v)})
-                            else:
-                                item.update({k:v})
+                                    item.update({k:v})
                         
         self.__dict__.update({
           "data": data,

--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -317,7 +317,7 @@ class Highchart(object):
         # DEM 2017/04/25: Make 'data' available as an array
         # ... this permits jinja2 array access to each data definition
         # ... which is useful for looping over multiple data sources
-        self.dataArr = [json.dumps(x, cls = HighchartsEncoder) for x in self.data_temp]
+        self.data_list = [json.dumps(x, cls = HighchartsEncoder) for x in self.data_temp]
 
         if self.drilldown_flag: 
             self.drilldown_data = json.dumps(self.drilldown_data_temp, cls = HighchartsEncoder)

--- a/highcharts/highcharts/templates/content.html
+++ b/highcharts/highcharts/templates/content.html
@@ -34,7 +34,7 @@
 
             $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
             {
-                chart.addSeries({{chart.dataArr[loop.index0]}});
+                chart.addSeries({{chart.data_list[loop.index0]}});
             });
 
           {% endfor %}

--- a/highcharts/highcharts/templates/content.html
+++ b/highcharts/highcharts/templates/content.html
@@ -28,7 +28,7 @@
             var chart = new Highcharts.Chart(option);
 
         {# DEM 2017/07/27: Use a list of JSONP data sources
-        {# DEM 2017/07/27: This is buggy and limited!  Improve this to be more generic! #}
+        {# DEM 2017/07/27: This implementation is limited and could easily be improved! #}
         {% if chart.jsonp_data_flag %}
           {% for data_url in chart.jsonp_data_url_list %}
 

--- a/highcharts/highcharts/templates/content.html
+++ b/highcharts/highcharts/templates/content.html
@@ -5,18 +5,13 @@
 
 {% block body_head %}
 
-        {% if chart.jsonp_data_flag %}
-            $.getJSON({{chart.jsonp_data_url}}, function ({{chart.jsonp_data}})
-                {
-        {% endif %} 
+        {% if chart.jscript_head_flag %}
+            {{chart.jscript_head}}
+        {% endif %}
 
 {% endblock body_head %}
 
 {% block body_content %}
-
-        {% if chart.jscript_head_flag %}
-            {{chart.jscript_head}}
-        {% endif %}
 
             Highcharts.setOptions({{chart.setoption}});
             var option = {{chart.option}};
@@ -25,15 +20,32 @@
             var geojson = {{chart.mapdata}}
         {% endif %}
 
-            var data = {{chart.data}};
-            option.series = data;
-
         {% if chart.drilldown_flag %}
             var drilldowndata = {{chart.drilldown_data}};
             option.drilldown.series = drilldowndata;
         {% endif %} 
 
             var chart = new Highcharts.Chart(option);
+
+        {# DEM 2017/07/27: Use a list of JSONP data sources
+        {# DEM 2017/07/27: This is buggy and limited!  Improve this to be more generic! #}
+        {% if chart.jsonp_data_flag %}
+          {% for data_url in chart.jsonp_data_url_list %}
+
+            $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
+            {
+                chart.addSeries({{chart.dataArr[loop.index0]}});
+            });
+
+          {% endfor %}
+        {% else %}
+            var data = {{chart.data}};
+            var dataLen = data.length;
+            for (var ix = 0; ix < dataLen; ix++) {
+                chart.addSeries(data[ix]);
+            }
+        {% endif %} 
+
 
         {% if chart.jscript_end_flag %}
             {{chart.jscript_end}}
@@ -72,9 +84,5 @@
 {% endblock body_content %}
 
 {% block body_end %}
-
-        {% if chart.jsonp_data_flag %}
-            });
-        {% endif %} 
 
 {% endblock body_end %}

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -301,7 +301,7 @@ class Highstock(object):
         # DEM 2017/04/25: Make 'data' available as an array
         # ... this permits jinja2 array access to each data definition
         # ... which is useful for looping over multiple data sources
-        self.dataArr = [json.dumps(x, cls = HighchartsEncoder) for x in self.data_temp]
+        self.data_list = [json.dumps(x, cls = HighchartsEncoder) for x in self.data_temp]
         
         if self.navi_seri_flag:        
             self.navi_seri = json.dumps(self.navi_seri_temp, cls = HighchartsEncoder)

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -83,7 +83,7 @@ class Highstock(object):
 
         # Data from jsonp
         self.jsonp_data_flag = False
-        self.jsonp_data_url_list = []
+        self.jsonp_data_url_list = [] # DEM 2017/04/25: List of JSON data sources
         
         # javascript
         self.jscript_head_flag = False
@@ -213,6 +213,8 @@ class Highstock(object):
             
             self.jsonp_data = data_name
         self.add_data_set(RawJavaScriptText(self.jsonp_data), series_type, name=name, **kwargs)
+        # DEM 2017/04/25: Append new JSON data source to a list instead of
+        #                 replacing whatever already exists
         self.jsonp_data_url_list.append(json.dumps(data_src))
 
 

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -295,6 +295,11 @@ class Highstock(object):
         self.option = json.dumps(self.options, cls = HighchartsEncoder)
         self.setoption = json.dumps(self.setOptions, cls = HighchartsEncoder) 
         self.data = json.dumps(self.data_temp, cls = HighchartsEncoder)
+
+        # DEM 2017/04/25: Make 'data' available as an array
+        # ... this permits jinja2 array access to each data definition
+        # ... which is useful for looping over multiple data sources
+        self.dataArr = [json.dumps(x, cls = HighchartsEncoder) for x in self.data_temp]
         
         if self.navi_seri_flag:        
             self.navi_seri = json.dumps(self.navi_seri_temp, cls = HighchartsEncoder)

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -83,6 +83,7 @@ class Highstock(object):
 
         # Data from jsonp
         self.jsonp_data_flag = False
+        self.jsonp_data_url_list = []
         
         # javascript
         self.jscript_head_flag = False
@@ -206,13 +207,13 @@ class Highstock(object):
         """
         if not self.jsonp_data_flag:
             self.jsonp_data_flag = True
-            self.jsonp_data_url = json.dumps(data_src) 
             
             if data_name == 'data':
                 data_name = 'json_'+ data_name
             
             self.jsonp_data = data_name
         self.add_data_set(RawJavaScriptText(self.jsonp_data), series_type, name=name, **kwargs)
+        self.jsonp_data_url_list.append(json.dumps(data_src))
 
 
     def add_navi_series(self, data, series_type="line", **kwargs):

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -31,7 +31,7 @@
 
             $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
             {
-                chart.addSeries({{chart.dataArr[loop.index0]}});
+                chart.addSeries({{chart.data_list[loop.index0]}});
             });
 
           {% endfor %}

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -24,7 +24,8 @@
             var chart = new Highcharts.StockChart(option);
 
 
-        {# This is buggy and limited!  Improve this to be more generic! #}
+        {# DEM 2017/04/25: Use a list of JSONP data sources
+        {# DEM 2017/04/25: This is buggy and limited!  Improve this to be more generic! #}
         {% if chart.jsonp_data_flag %}
           {% for data_url in chart.jsonp_data_url_list %}
 

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -5,24 +5,16 @@
 
 {% block body_head %}
 
-        {% if chart.jsonp_data_flag %}
-            $.getJSON({{chart.jsonp_data_url}}, function ({{chart.jsonp_data}})
-                {
-        {% endif %} 
+        {% if chart.jscript_head_flag %}
+            {{chart.jscript_head}}
+        {% endif %}
 
 {% endblock body_head %}
 
 {% block body_content %}
 
-        {% if chart.jscript_head_flag %}
-            {{chart.jscript_head}}
-        {% endif %}
-
             Highcharts.setOptions({{chart.setoption}});
             var option = {{chart.option}};
-
-            var data = {{chart.data}};
-            option.series = data;
 
         {% if chart.navi_seri_flag %}
             var navi_data = {{chart.navi_seri}}
@@ -31,16 +23,35 @@
 
             var chart = new Highcharts.StockChart(option);
 
-        {% if chart.jscript_end_flag %}
-            {{chart.jscript_end}}
-        {% endif %}
+
+
+        {# This is buggy and limited!  Improve this to be more generic! #}
+        {% if chart.jsonp_data_flag %}
+          {% for data_url in chart.jsonp_data_url_list %}
+
+            $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
+            {
+                var data = {{chart.data}};
+                chart.addSeries(data[{{loop.index0}}]);
+            });
+
+          {% endfor %}
+        {% else %}
+
+            var data = {{chart.data}};
+            var dataLen = data.length;
+            for (var ix = 0; ix < dataLen; ix++) {
+                chart.addSeries(data[ix]);
+            }
+
+        {% endif %} 
 
 {% endblock body_content %}
 
 {% block body_end %}
 
-        {% if chart.jsonp_data_flag %}
-            });
-        {% endif %} 
+        {% if chart.jscript_end_flag %}
+            {{chart.jscript_end}}
+        {% endif %}
 
 {% endblock body_end %}

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -24,15 +24,13 @@
             var chart = new Highcharts.StockChart(option);
 
 
-
         {# This is buggy and limited!  Improve this to be more generic! #}
         {% if chart.jsonp_data_flag %}
           {% for data_url in chart.jsonp_data_url_list %}
 
             $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
             {
-                var data = {{chart.data}};
-                chart.addSeries(data[{{loop.index0}}]);
+                chart.addSeries({{chart.dataArr[loop.index0]}});
             });
 
           {% endfor %}

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -25,7 +25,7 @@
 
 
         {# DEM 2017/04/25: Use a list of JSONP data sources
-        {# DEM 2017/04/25: This is buggy and limited!  Improve this to be more generic! #}
+        {# DEM 2017/07/27: This implementation is limited and could easily be improved! #}
         {% if chart.jsonp_data_flag %}
           {% for data_url in chart.jsonp_data_url_list %}
 

--- a/highcharts/highstock/templates/page.html
+++ b/highcharts/highstock/templates/page.html
@@ -8,5 +8,6 @@
     </head>
     <body style="margin:0;padding:0">
         {{ chart.content }}
+        {{ chart.other }}
     </body>
 </html>


### PR DESCRIPTION
Modify Highchart and Highstock classes to support multiple JSONP sources within a single chart in order to display multiple graph lines loaded at runtime via ajax / jsonp calls.  The implementation is based on the original python-highcharts design only adding in code for looping over multiple jsonp sources instead of assuming only a single source could be used.