### PR TITLE
dateTimeLabelFormats add list support

### DIFF
--- a/highcharts/highstock/common.py
+++ b/highcharts/highstock/common.py
@@ -486,14 +486,14 @@ class Handles(CommonObject):
 
 class DateTimeLabelFormats(CommonObject):
     ALLOWED_OPTIONS = {
-    "millisecond": basestring,
-    "second": basestring,
-    "minute": basestring,
-    "hour": basestring,
-    "day": basestring,
-    "week": basestring,
-    "month": basestring,
-    "year": basestring,
+    "millisecond": (basestring, list),
+    "second": (basestring, list),
+    "minute": (basestring, list),
+    "hour": (basestring, list),
+    "day": (basestring, list),
+    "week": (basestring, list),
+    "month": (basestring, list),
+    "year": (basestring, list),
     }
 
 class DataGrouping(CommonObject):


### PR DESCRIPTION
https://api.highcharts.com/highstock/plotOptions.series.dataGrouping

dateTimeLabelFormats: object
Datetime formats for the header of the tooltip in a stock chart. The format can vary within a chart depending on the currently selected time range and the current data grouping.

The default formats are:

{
    millisecond: [
        '%A, %b %e, %H:%M:%S.%L', '%A, %b %e, %H:%M:%S.%L', '-%H:%M:%S.%L'
    ],
    second: ['%A, %b %e, %H:%M:%S', '%A, %b %e, %H:%M:%S', '-%H:%M:%S'],
    minute: ['%A, %b %e, %H:%M', '%A, %b %e, %H:%M', '-%H:%M'],
    hour: ['%A, %b %e, %H:%M', '%A, %b %e, %H:%M', '-%H:%M'],
    day: ['%A, %b %e, %Y', '%A, %b %e', '-%A, %b %e, %Y'],
    week: ['Week from %A, %b %e, %Y', '%A, %b %e', '-%A, %b %e, %Y'],
    month: ['%B %Y', '%B', '-%B %Y'],
    year: ['%Y', '%Y', '-%Y']
}
