### PR TITLE
Highmaps bugfix and CSSsource clear.

### DIFF
--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -337,7 +337,7 @@ class Highchart(object):
         """generate HTML header content"""
         
         if self.drilldown_flag:
-            self.add_JSsource('http://code.highcharts.com/modules/9/drilldown.js')
+            self.add_JSsource('https://code.highcharts.com/9/modules/drilldown.js')
 
 
 

--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -337,7 +337,7 @@ class Highchart(object):
         """generate HTML header content"""
         
         if self.drilldown_flag:
-            self.add_JSsource('http://code.highcharts.com/modules/drilldown.js')
+            self.add_JSsource('http://code.highcharts.com/modules/9/drilldown.js')
 
 
 

--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -75,10 +75,7 @@ class Highchart(object):
             ]
 
         # set CSS src
-        self.CSSsource = [
-                'https://www.highcharts.com/highslide/highslide.css',
-
-            ]
+        self.CSSsource = []
 
         self.offline = kwargs.get("offline", False)
 

--- a/highcharts/highmaps/highmaps.py
+++ b/highcharts/highmaps/highmaps.py
@@ -378,7 +378,7 @@ class Highmap(object):
         #Highcharts lib/ needs to make sure it's up to date
         
         if self.drilldown_flag:
-            self.add_JSsource('https://code.highcharts.com/maps/modules/drilldown.js')
+            self.add_JSsource('https://code.highcharts.com/maps/modules/9/drilldown.js')
 
         self.header_css = [
             '<link href="%s" rel="stylesheet" />' % h for h in self.CSSsource

--- a/highcharts/highmaps/highmaps.py
+++ b/highcharts/highmaps/highmaps.py
@@ -66,17 +66,15 @@ class Highmap(object):
         # Set Javascript src
         self.JSsource = [
                 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
-                'https://code.highcharts.com/maps/6/highmaps.js',
-                'https://code.highcharts.com/6/highcharts.js',
-                'https://code.highcharts.com/maps/6/modules/map.js',
-                'https://code.highcharts.com/maps/6/modules/data.js',
-                'https://code.highcharts.com/maps/6/modules/exporting.js'
+                'https://code.highcharts.com/maps/9/highmaps.js',
+                'https://code.highcharts.com/9/highcharts.js',
+                'https://code.highcharts.com/maps/9/modules/map.js',
+                'https://code.highcharts.com/maps/9/modules/data.js',
+                'https://code.highcharts.com/maps/9/modules/exporting.js'
             ]
 
         # set CSS src
-        self.CSSsource = [
-                'https://www.highcharts.com/highslide/highslide.css',
-            ]
+        self.CSSsource = []
         # Set data
         self.data = []
         self.data_temp = []

--- a/highcharts/highmaps/highmaps.py
+++ b/highcharts/highmaps/highmaps.py
@@ -378,7 +378,7 @@ class Highmap(object):
         #Highcharts lib/ needs to make sure it's up to date
         
         if self.drilldown_flag:
-            self.add_JSsource('https://code.highcharts.com/maps/modules/9/drilldown.js')
+            self.add_JSsource('https://code.highcharts.com/maps/9/modules/drilldown.js')
 
         self.header_css = [
             '<link href="%s" rel="stylesheet" />' % h for h in self.CSSsource

--- a/highcharts/highmaps/templates/content.html
+++ b/highcharts/highmaps/templates/content.html
@@ -26,7 +26,7 @@
             var option = {{chart.option}};
 
         {% if chart.mapdata_flag %}
-            var geojson = {{chart.mapdata}}
+            var geojson = $.parseJSON({{chart.mapdata}});
         {% endif %}
 
             var data = {{chart.data}};

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -68,10 +68,7 @@ class Highstock(object):
             ]
 
         # set CSS src
-        self.CSSsource = [
-                'https://www.highcharts.com/highslide/highslide.css',
-
-            ]
+        self.CSSsource = []
         # set data
         self.data = []
         self.data_temp = []


### PR DESCRIPTION
The file `highmaps/templates/content.html` has a bug that prevents JavaScript from parsing a custom GeoJSON map. Added a `$.parseJSON();` call to fix it.

Most of Highcharts 6 libraries for Maps don't work properly, so `JSsource` links were updated to version 9. Most maps work fine with version 7, but when adding a custom GeoJSON map, the least version needed is 9. 

The CSS `https://www.highcharts.com/highslide/highslide.css` is not available anymore so it's been removed from `CSSsource` definitions on `highcharts/highcharts.py`, `highmaps/highmaps.py`, and `highstocks/highstocks.py`.